### PR TITLE
Build and publish docker images in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,7 @@ jobs:
           name: "Storing logs"
           path: logs
 
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
 
       - run:
           name: "Building and verifying docker image"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,8 @@ jobs:
           name: "Building and verifying docker image"
           command: |
             docker build . -t $IMAGE_NAME:$TAG
-            docker run -d --name be-neutral $IMAGE_NAME:$TAG
+            docker run -it -d -p 8080:8080 --name be-neutral $IMAGE_NAME:$TAG
+            docker ps
             docker exec be-neutral curl --retry 10 --retry-connrefused http://localhost:8080
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ jobs:
     docker:
       - image: circleci/openjdk:11-jdk # primary container
       # Service dependencies documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/buildpack-deps:curl
       # - image: circleci/postgres:9.4
 
     working_directory: ~/repo
@@ -55,15 +54,8 @@ jobs:
       - setup_remote_docker
 
       - run:
-          name: "Building and verifying docker image"
+          name: "Building and publishing docker image"
           command: |
             docker build . -t $IMAGE_NAME:$TAG
-            docker run -it -d -p 8080:8080 --name be-neutral $IMAGE_NAME:$TAG
-            docker ps
-            docker exec be-neutral curl --retry 10 --retry-connrefused http://localhost:8080
-
-      - run:
-          name: "Publishing docker image"
-          command: |
             echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
             docker push $IMAGE_NAME:$TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ jobs:
     working_directory: ~/repo
 
     environment:
+      IMAGE_NAME: marihak/be-neutral
+      TAG: latest  # 0.1.$CIRCLE_BUILD_NUM
+
       # JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
 
@@ -33,16 +36,34 @@ jobs:
             - ~/.m2
           key: v1-dependencies-{{ checksum "pom.xml" }}
 
-      # Run tests!
-      - run: mvn verify -Dsurefire.useSystemClassLoader=false -Dfailsafe.useSystemClassLoader=false
+      - run:
+          name: "Running tests!"
+          command: mvn verify -Dsurefire.useSystemClassLoader=false -Dfailsafe.useSystemClassLoader=false
 
       - store_test_results:
           path: target/test-results
 
       - store_artifacts:
-          name: Storing test results
+          name: "Storing test results"
           path: target/test-results
           destination: test-results
       - store_artifacts:
-          name: Storing logs
+          name: "Storing logs"
           path: logs
+
+      - setup_remote_docker:
+          docker_layer_caching: true
+
+      - run:
+          name: "Building and verifying docker image"
+          command: |
+                     docker build . -t $IMAGE_NAME:$TAG
+            # Start service and check that it’s running
+                     docker run -d --name be-neutral $IMAGE_NAME:$TAG
+                     docker exec be-neutral curl --retry 10 --retry-connrefused http://localhost:8080
+
+      - run:
+          name: "Publishing docker image"
+          command: |
+            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+            docker push $IMAGE_NAME:$TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
     docker:
       - image: circleci/openjdk:11-jdk # primary container
       # Service dependencies documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: circleci/buildpack-deps:curl
       # - image: circleci/postgres:9.4
 
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,10 +57,9 @@ jobs:
       - run:
           name: "Building and verifying docker image"
           command: |
-                     docker build . -t $IMAGE_NAME:$TAG
-            # Start service and check that it’s running
-                     docker run -d --name be-neutral $IMAGE_NAME:$TAG
-                     docker exec be-neutral curl --retry 10 --retry-connrefused http://localhost:8080
+            docker build . -t $IMAGE_NAME:$TAG
+            docker run -d --name be-neutral $IMAGE_NAME:$TAG
+            docker exec be-neutral curl --retry 10 --retry-connrefused http://localhost:8080
 
       - run:
           name: "Publishing docker image"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# any files or directories starting with a '.'
+.*
+logs/
+frontend/
+images/


### PR DESCRIPTION
Publish docker image with backend as part of CI.

Image location: https://hub.docker.com/repository/docker/marihak/be-neutral

Limitations: one workflow for all branches, they overwrite `latest` tag.