### PR TITLE
Verify docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,20 +77,24 @@ jobs:
       - setup_remote_docker
 
       - run:
-          name: "Building and publishing docker image"
+          name: "Building docker image"
           command: |
             IMAGE_FULL_NAME=$DOCKER_USER/$IMAGE_NAME
             IMAGE_ID=$(docker build . -q -t $IMAGE_FULL_NAME)
             docker tag $IMAGE_ID $IMAGE_FULL_NAME:$TAG
-            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
-            docker push $IMAGE_FULL_NAME
 
       - run:
-          name: "Start service and check that it’s running"
+          name: "Starting the service and checking that it’s running"
           command: |
             echo $IBM_DB_URL
             docker run -it -d -p 8080:8080 -e IBM_IAM_KEY -e IBM_DB_URL --name be-neutral $DOCKER_USER/$IMAGE_NAME
             docker exec be-neutral curl -4 --retry 10 --retry-connrefused http://localhost:8080
+
+      - run:
+          name: "Publishing docker image"
+          command: |
+            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+            docker push $DOCKER_USER/$IMAGE_NAME
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ version: 2.1
 parameters:
   publish-docker-image:
     type: boolean
-    default: false
+    default: true
   image-tag:
     type: string
-    default: << pipeline.git.branch >>
+    default: "test" # << pipeline.git.branch >>
 
 jobs:
   run-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,8 +90,7 @@ jobs:
           command: |
             echo $IBM_DB_URL
             docker run -it -d -p 8080:8080 -e IBM_IAM_KEY -e IBM_DB_URL --name be-neutral $DOCKER_USER/$IMAGE_NAME
-            docker ps
-            docker exec be-neutral curl --retry 10 --retry-connrefused http://localhost:8080
+            docker exec be-neutral curl -4 --retry 10 --retry-connrefused http://localhost:8080
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
       - run:
           name: "Start service and check that it’s running"
           command: |
-            docker run -it -d -p 8080:8080 --name be-neutral $DOCKER_USER/$IMAGE_NAME
+            docker run -it -d -p 8080:8080 -e IBM_IAM_KEY -e IBM_DB_URL --name be-neutral $DOCKER_USER/$IMAGE_NAME
             docker ps
             docker exec be-neutral curl --retry 10 --retry-connrefused http://localhost:8080
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ jobs:
       - run:
           name: "Start service and check that it’s running"
           command: |
+            echo $IBM_DB_URL
             docker run -it -d -p 8080:8080 -e IBM_IAM_KEY -e IBM_DB_URL --name be-neutral $DOCKER_USER/$IMAGE_NAME
             docker ps
             docker exec be-neutral curl --retry 10 --retry-connrefused http://localhost:8080

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,13 @@ jobs:
             echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
             docker push $IMAGE_FULL_NAME
 
+      - run:
+          name: "Start service and check that it’s running"
+          command: |
+            docker run -it -d -p 8080:8080 --name be-neutral $DOCKER_USER/$IMAGE_NAME
+            docker ps
+            docker exec be-neutral curl --retry 10 --retry-connrefused http://localhost:8080
+
 workflows:
   version: 2.1
   build-only:

--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ http://www.beNeutral.eu
 How to start the BeNeutral application
 -------------------------
 
-1. You will need IBM Cloudant database credentials. \
-    `export IBM_DB_URL=your-cloudant-db-url` \
-    `export IBM_IAM_KEY=your-ibm-iam-key` \
-    alternatively, put your url and iamKey directly in `/config.yml` and `/src/test/resources/test-config.yml` 
-    
+1. You will need IBM Cloudant database credentials. The app config file expects them as the environment variables.
+   ```
+    export IBM_DB_URL=your-cloudant-db-url
+    export IBM_IAM_KEY=your-ibm-iam-key
+   ```
 1. To run the application, you can either build and run it in your env or run it in a container. Either way, the BeNeutral banner in the log indicates the server is up.
     * Un-containerized app server
         1. Run `mvn package` to build the application
         1. Start application with `java -jar target/be-neutral-1.0-SNAPSHOT.jar server config.yml`
     * Run the server in a docker container, using the latest image from the master branch, published to dockerhub: \
-        `docker run -p 8080:8080 -p 8081:8081 marihak/be-neutral`
+        `docker run -p 8080:8080 -p 8081:8081 -e IBM_IAM_KEY -e IBM_DB_URL marihak/be-neutral`
 
 1. To check that the application is running enter url `http://localhost:8080/api/v1/`
 1. You can find api documentation at `http://localhost:8080/api/v1/swagger`


### PR DESCRIPTION
Verify the app in docker image starts correctly.

Cloudant credentials are passed to docker container with `-e` option from the environment variables.

`curl -4` will use IPv4 only as a workaround to curl issues with ignored retry after `Connection refused`.
@see curl/curl#5080 Retry completely ignored in docker container
